### PR TITLE
TypeScript typings for WarningsToErrorsPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Change every warning as error to ensure safe build",
   "main": "index.js",
+  "types": "typings.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/taehwanno/warnings-to-errors-webpack-plugin"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,8 @@
+import { Compiler } from "webpack";
+
+export = WarningsToErrorsPlugin;
+
+declare class WarningsToErrorsPlugin {
+    constructor();
+    apply(compiler: Compiler): void;
+}


### PR DESCRIPTION
The new file typings.d.ts contains TypeScript typings for webpack that should
be usable for a webpack version that is compatible with typescript
configuration.

If you open typings.d.ts in an IDE you will se a warning that webpack isn't
installed, or that types are missing. This is because this repository has
webpack as a peer dependency, so the user of this library will have to select
a webpack version and install that. At that point the typings will be available
at the client side (the one that does npm install or yarn add of
warnings-to-errors-webpack-plugin).

Fixes taehwanno/warnings-to-errors-webpack-plugin#58